### PR TITLE
settings: Hide hardware revision if empty.

### DIFF
--- a/src/com/android/settings/deviceinfo/hardwareinfo/HardwareRevisionPreferenceController.java
+++ b/src/com/android/settings/deviceinfo/hardwareinfo/HardwareRevisionPreferenceController.java
@@ -18,6 +18,7 @@ package com.android.settings.deviceinfo.hardwareinfo;
 
 import android.content.Context;
 import android.os.SystemProperties;
+import android.text.TextUtils;
 
 import com.android.settings.R;
 import com.android.settings.core.BasePreferenceController;
@@ -31,8 +32,8 @@ public class HardwareRevisionPreferenceController extends BasePreferenceControll
 
     @Override
     public int getAvailabilityStatus() {
-        return mContext.getResources().getBoolean(R.bool.config_show_device_model)
-                ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
+        return mContext.getResources().getBoolean(R.bool.config_show_device_model) &&
+                !TextUtils.isEmpty(getSummary()) ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
     }
 
     @Override


### PR DESCRIPTION
Showed if 'ro.boot.hardware.revision' is set in prop.